### PR TITLE
Item overrides fix

### DIFF
--- a/SmallTownResponders/media/lua/server/overrides/itemoverrides.lua
+++ b/SmallTownResponders/media/lua/server/overrides/itemoverrides.lua
@@ -379,12 +379,14 @@ ItemOverrides.overrideContainer = function(container, policeZones)
                 newType = ItemOverrides.itemSwaps[itemType].Default
             end
 
-            if newType then
+            if newType ~= nil then
                 if type(newType) == 'table' then
                     newType = newType[ZombRand(#newType)+1]
                 end
                 container:Remove(item)
-                container:AddItem(newType)
+                if newType then
+                    container:AddItem(newType)
+                end
             end
         end
     end

--- a/SmallTownResponders/media/lua/server/overrides/itemoverrides.lua
+++ b/SmallTownResponders/media/lua/server/overrides/itemoverrides.lua
@@ -369,7 +369,7 @@ ItemOverrides.overrideContainer = function(container, policeZones)
 
     local items = container:getItems()
     local getItem = items.get
-    for i=0,items:size()-1 do
+    for i = items:size()-1, 0, -1 do
         local item = getItem(items, i)
 
         local itemType = item:getFullType()


### PR DESCRIPTION
fixes some items being skipped by item overrides, and allows items to be removed instead of replaced by specifying ``false`` instead of an item type in the replacement table